### PR TITLE
Drux doesn't work with Drush 5

### DIFF
--- a/lib/ExtensionInfo.php
+++ b/lib/ExtensionInfo.php
@@ -191,7 +191,7 @@ class drux_ExtensionInfo {
   }
 
   function downloadProjects($projects) {
-    $result = drush_invoke_process_args('pm-download', array_keys($projects), array('y' => TRUE));
+    $result = drush_invoke_process('@self','pm-download', $projects, array('y' => TRUE));
     $this->refresh();
     return TRUE;
   }


### PR DESCRIPTION
It seems drush_invoke_process_args() was removed from Drush 5 api, so drush dep-en cannot work anymore.

lib/ExtensionInfo.php line 194
$result = drush_invoke_process_args('pm-download', array_keys($projects), array('y' => TRUE));
should be replaced with
$result = drush_invoke_process('@self','pm-download', $projects, array('y' => TRUE));
